### PR TITLE
Add state_variable_names interface

### DIFF
--- a/src/ConstitutiveModels.jl
+++ b/src/ConstitutiveModels.jl
@@ -9,6 +9,7 @@ export cauchy_stress,
        helmholtz_free_energy,
        initialize_props,
        initialize_state,
+       state_variable_names,
        material_hessian,
        material_tangent,
        pk1_stress

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -30,6 +30,15 @@ function initialize_state(
     return zeros(float_type, NS)
 end
 
+"""
+Return human-readable names for each state variable, in storage order.
+Default fallback generates generic names: ["state_1", "state_2", ...].
+Models should override this to provide meaningful names.
+"""
+function state_variable_names(::AbstractConstitutiveModel{NP, NS}) where {NP, NS}
+    return ["state_$i" for i in 1:NS]
+end
+
 @inline function unpack_props(
     ::AbstractConstitutiveModel{NP, NS},
     props,

--- a/src/mechanics/plasticity/FiniteDefJ2Plasticity.jl
+++ b/src/mechanics/plasticity/FiniteDefJ2Plasticity.jl
@@ -43,6 +43,15 @@ function initialize_state(::FiniteDefJ2Plasticity, float_type = Float64)
     return float_type[1, 0, 0, 0, 1, 0, 0, 0, 1, 0]   # vec(I) ++ 0
 end
 
+function state_variable_names(::FiniteDefJ2Plasticity)
+    return [
+        "Fp_11", "Fp_21", "Fp_31",
+        "Fp_12", "Fp_22", "Fp_32",
+        "Fp_13", "Fp_23", "Fp_33",
+        "eqps",
+    ]
+end
+
 # ---------------------------------------------------------------------------
 # Internal: Simo-Hughes stress update (BOX 9.1)
 # ---------------------------------------------------------------------------

--- a/src/mechanics/plasticity/LinearElastoPlasticity.jl
+++ b/src/mechanics/plasticity/LinearElastoPlasticity.jl
@@ -142,3 +142,11 @@ function unpack_state(::LinearElastoPlasticity, Z)
     α = Z[7]
     return ε_p, α
 end
+
+function state_variable_names(::LinearElastoPlasticity)
+    return [
+        "ep_xx", "ep_yy", "ep_zz",
+        "ep_yz", "ep_xz", "ep_xy",
+        "eqps",
+    ]
+end


### PR DESCRIPTION
## Summary
- Add `state_variable_names(::AbstractConstitutiveModel)` to `Interface.jl` with generic fallback returning `["state_1", "state_2", ...]`
- Override for `FiniteDefJ2Plasticity`: `["Fp_11", ..., "Fp_33", "eqps"]`
- Override for `LinearElastoPlasticity`: `["ep_xx", ..., "ep_xy", "eqps"]`
- Export `state_variable_names` from the module