### PR TITLE
Add p_wave_modulus for stable time step estimation

### DIFF
--- a/src/ConstitutiveModels.jl
+++ b/src/ConstitutiveModels.jl
@@ -10,6 +10,7 @@ export cauchy_stress,
        initialize_props,
        initialize_state,
        state_variable_names,
+       p_wave_modulus,
        material_hessian,
        material_tangent,
        pk1_stress

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -39,6 +39,12 @@ function state_variable_names(::AbstractConstitutiveModel{NP, NS}) where {NP, NS
     return ["state_$i" for i in 1:NS]
 end
 
+"""
+Return the p-wave modulus M for stable time step estimation.
+Models must override this — no generic fallback.
+"""
+function p_wave_modulus end
+
 @inline function unpack_props(
     ::AbstractConstitutiveModel{NP, NS},
     props,

--- a/src/mechanics/hyperelasticity/ArrudaBoyce.jl
+++ b/src/mechanics/hyperelasticity/ArrudaBoyce.jl
@@ -86,3 +86,5 @@ end
 #     P = P_vol + P_dev
 #     return P
 # end
+
+p_wave_modulus(::ArrudaBoyce, props) = props[1] + 4 * props[2] / 3

--- a/src/mechanics/hyperelasticity/Gent.jl
+++ b/src/mechanics/hyperelasticity/Gent.jl
@@ -105,3 +105,5 @@ function material_tangent(
     ℂ = ℂ_vol + ℂ_dev
     return _convect_tangent(ℂ, S, F)
 end
+
+p_wave_modulus(::Gent, props) = props[1] + 4 * props[2] / 3

--- a/src/mechanics/hyperelasticity/Hencky.jl
+++ b/src/mechanics/hyperelasticity/Hencky.jl
@@ -139,3 +139,5 @@ function material_tangent(
 
     return _convect_tangent(ℂ, S, F)
 end
+
+p_wave_modulus(::Hencky, props) = props[1] + 4 * props[2] / 3

--- a/src/mechanics/hyperelasticity/LinearElastic.jl
+++ b/src/mechanics/hyperelasticity/LinearElastic.jl
@@ -70,3 +70,5 @@ function cauchy_stress(
     σ = λ * tr(ε) * I + 2. * μ * ε
     return σ
 end
+
+p_wave_modulus(::LinearElastic, props) = props[1] + 2 * props[2]

--- a/src/mechanics/hyperelasticity/MooneyRivlin.jl
+++ b/src/mechanics/hyperelasticity/MooneyRivlin.jl
@@ -137,3 +137,5 @@ end
 
 #     return _convect_tangent(ℂ, S, F)
 # end
+
+p_wave_modulus(::MooneyRivlin, props) = props[1] + 4 * (props[2] + props[3]) / 3

--- a/src/mechanics/hyperelasticity/NeoHookean.jl
+++ b/src/mechanics/hyperelasticity/NeoHookean.jl
@@ -107,3 +107,5 @@ function material_tangent(
 
     return _convect_tangent(ℂ, S, F)
 end
+
+p_wave_modulus(::NeoHookean, props) = props[1] + 4 * props[2] / 3

--- a/src/mechanics/hyperelasticity/SaintVenantKirchhoff.jl
+++ b/src/mechanics/hyperelasticity/SaintVenantKirchhoff.jl
@@ -83,3 +83,5 @@ function material_tangent(
 
     return _convect_tangent(ℂ, S, F)
 end
+
+p_wave_modulus(::SaintVenantKirchhoff, props) = props[1] + 2 * props[2]

--- a/src/mechanics/hyperelasticity/SethHill.jl
+++ b/src/mechanics/hyperelasticity/SethHill.jl
@@ -92,3 +92,5 @@ function pk1_stress(
 end
 
 # material_tangent falls through to the AD default in CommonMethods.jl
+
+p_wave_modulus(::SethHill, props) = props[1] + 4 * props[2] / 3

--- a/src/mechanics/plasticity/FiniteDefJ2Plasticity.jl
+++ b/src/mechanics/plasticity/FiniteDefJ2Plasticity.jl
@@ -248,3 +248,5 @@ function material_tangent(
     return _sh_j2_tangent(props, F, Z_old, P,
                            s_new, be_bar_tr, s_trial_norm, μ̄, Δγ, α_n)
 end
+
+p_wave_modulus(::FiniteDefJ2Plasticity, props) = props[1] + 2 * props[2]


### PR DESCRIPTION
## Summary
- Add `p_wave_modulus(model, props)` to the `AbstractConstitutiveModel` interface for CFL-based stable time step estimation in explicit dynamics
- Overrides for all hyperelastic models (NeoHookean, Hencky, LinearElastic, SaintVenantKirchhoff, ArrudaBoyce, MooneyRivlin, Gent, SethHill) and FiniteDefJ2Plasticity
- Two property layout families: `[κ, μ, ...]` → `M = κ + 4μ/3`, `[λ, μ, ...]` → `M = λ + 2μ`
- Export `p_wave_modulus` from the module
