### PR TITLE
Restore FiniteDefJ2Plasticity and fix the p_wave_modulus wrappers

### DIFF
--- a/src/ConstitutiveModels.jl
+++ b/src/ConstitutiveModels.jl
@@ -58,6 +58,7 @@ export LinearThermalExpansion
 export VonMises
 
 # actual models
+export FiniteDefJ2Plasticity
 export Hyperelastic
 export Hypoelastic
 export LinearElastic
@@ -92,6 +93,7 @@ include("modules/plasticity/Plasticity.jl")
 include("modules/thermal_expansion/ThermalExpansion.jl")
 
 # models
+include("models/FiniteDefJ2Plasticity.jl")
 include("models/Hyperelastic.jl")
 include("models/Hypoelastic.jl")
 include("models/LinearElastic.jl")

--- a/src/models/FiniteDefJ2Plasticity.jl
+++ b/src/models/FiniteDefJ2Plasticity.jl
@@ -14,7 +14,8 @@
 #   Z[1:9]  = vec(Fᵖ)  column-major; initial value = vec(I₃)
 #   Z[10]   = α        accumulated equivalent plastic strain; initial 0
 #
-# Properties (NP = 4): [λ, μ, σ_y, H]
+# Properties (NP = 5): [ρ, λ, μ, σ_y, H]
+#   ρ     : Lagrangian-frame density; every model carries it as props[1]
 #   λ, μ  : Lamé constants (converted to κ = λ + 2μ/3 internally)
 #   σ_y   : initial yield stress
 #   H     : linear isotropic hardening modulus
@@ -22,7 +23,7 @@
 """
 $(TYPEDEF)
 """
-struct FiniteDefJ2Plasticity <: AbstractMechanicalModel{4, 10}
+struct FiniteDefJ2Plasticity <: AbstractConstitutiveModel
 end
 
 """
@@ -242,7 +243,7 @@ end
 
 function material_tangent(
     ::FiniteDefJ2Plasticity,
-    props, Δt, Z_old, Z_new,
+    props, Z_old, Z_new, Δt,
     ∇u, θ
 )
     F = ∇u + one(∇u)
@@ -251,6 +252,28 @@ function material_tangent(
     Z_new .= state_new_vec
     return _sh_j2_tangent(props, F, Z_old, P,
                            s_new, be_bar_tr, s_trial_norm, μ̄, Δγ, α_n)
+end
+
+"""
+Cauchy stress σ = J⁻¹ P Fᵀ.
+
+`FiniteDefJ2Plasticity` subtypes `AbstractConstitutiveModel` directly rather
+than `AbstractHyperelasticModel` -- it is path dependent, so the hyperelastic
+defaults (AD tangents from a stored energy) do not apply to it.  That also means
+it does not inherit the hyperelastic `cauchy_stress` fallback, so the push-forward
+is written out here.  Consumers that report stress (e.g. Carina's output writer)
+call this.
+$(TYPEDSIGNATURES)
+"""
+function cauchy_stress(
+    model::FiniteDefJ2Plasticity,
+    props, Z_old, Z_new, Δt,
+    ∇u, θ
+)
+    F = ∇u + one(∇u)
+    J = det(F)
+    P = pk1_stress(model, props, Z_old, Z_new, Δt, ∇u, θ)
+    return (1 / J) * dot(P, transpose(F))
 end
 
 p_wave_modulus(::FiniteDefJ2Plasticity, props) = props[2] + 2 * props[3]

--- a/src/models/Hyperelastic.jl
+++ b/src/models/Hyperelastic.jl
@@ -42,7 +42,7 @@ function material_tangent(
     return material_tangent(model.model, props, ∇u, θ)
 end
 
-function p_wave_modulus(::Hyperelastic, props) 
+function p_wave_modulus(model::Hyperelastic, props)
     props = module_props(model.model, props, 2)
     return p_wave_modulus(model.model, props)
 end

--- a/src/models/LinearElastic.jl
+++ b/src/models/LinearElastic.jl
@@ -44,7 +44,7 @@ function spatial_tangent(
     return spatial_tangent(model.model, props, ε, θ)
 end
 
-function p_wave_modulus(::LinearElastic, props) 
+function p_wave_modulus(model::LinearElastic, props)
     props = module_props(model.model, props, 2)
     return p_wave_modulus(model.model, props)
 end

--- a/src/models/LinearElastoplastic.jl
+++ b/src/models/LinearElastoplastic.jl
@@ -121,7 +121,7 @@ function spatial_tangent(
     return C
 end
 
-function p_wave_modulus(::LinearElastoplastic, props) 
+function p_wave_modulus(model::LinearElastoplastic, props)
     props = module_props(model.elastic_model, props, 2)
     return p_wave_modulus(model.elastic_model, props)
 end

--- a/src/models/LinearThermoelastic.jl
+++ b/src/models/LinearThermoelastic.jl
@@ -85,7 +85,7 @@ function helmholtz_free_energy(
     return ψ_m + ψ_t + ψ_mixed
 end
 
-function p_wave_modulus(::LinearThermoelastic, props) 
+function p_wave_modulus(model::LinearThermoelastic, props)
     props = module_props(model.elastic_model, props, 2)
     return p_wave_modulus(model.elastic_model, props)
 end

--- a/test/models/TestFiniteDefJ2Plasticity.jl
+++ b/test/models/TestFiniteDefJ2Plasticity.jl
@@ -1,0 +1,145 @@
+# FiniteDefJ2Plasticity had no tests, which is how it came to be silently
+# dropped from the module: the modularity refactor removed its `include` and
+# `export` and nothing failed.  These tests pin the interface it must satisfy
+# (so a future refactor that strands it again fails here) as well as its
+# physics.
+
+function test_finite_def_j2_interface()
+    model = FiniteDefJ2Plasticity()
+
+    # Reachable through the module, not just as a file on disk.
+    @test isdefined(ConstitutiveModels, :FiniteDefJ2Plasticity)
+    @test model isa CM.AbstractConstitutiveModel
+
+    inputs = Dict(
+        "density"           => 2700.0,
+        "Young's modulus"   => 70.0e9,
+        "Poisson's ratio"   => 0.36,
+        "yield stress"      => 250.0e6,
+        "hardening modulus" => 0.7e9,
+    )
+    props = initialize_props(model, inputs)
+
+    # Density is props[1] for every model; the mass matrix and wave-speed
+    # estimates of downstream codes depend on it.
+    @test length(props) == num_properties(model)
+    @test num_properties(model) == 5
+    @test props[1] == 2700.0
+    @test density(model, props, nothing, nothing, 0.0, nothing, 0.0) == 2700.0
+
+    # p-wave modulus is λ + 2μ, read from the density-offset property layout.
+    @test p_wave_modulus(model, props) ≈ props[2] + 2 * props[3]
+
+    # State: Fᵖ = I₃ then α.
+    Z = initialize_state(model)
+    @test length(Z) == num_state_variables(model) == 10
+    @test Z[1:9] == [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    @test Z[10] == 0
+    @test last(state_variable_names(model)) == "eqps"
+end
+
+function test_finite_def_j2_uniaxial_strain()
+    model = FiniteDefJ2Plasticity()
+    inputs = Dict(
+        "density"           => 2700.0,
+        "Young's modulus"   => 70.0e9,
+        "Poisson's ratio"   => 0.36,
+        "yield stress"      => 250.0e6,
+        "hardening modulus" => 0.7e9,
+    )
+    props = initialize_props(model, inputs)
+    λ, μ, σ_y = props[2], props[3], props[4]
+
+    # Uniaxial strain: ∇u = ε e₁⊗e₁.  Below yield the response is linear with
+    # the constrained modulus λ + 2μ and no plastic flow.
+    ε = 1.0e-3
+    ∇u = Tensor{2, 3}((i, j) -> (i == 1 && j == 1) ? ε : 0.0)
+    Z_old = initialize_state(model)
+    Z_new = copy(Z_old)
+    σ = cauchy_stress(model, props, Z_old, Z_new, 0.0, ∇u, 0.0)
+
+    # von Mises check: ‖s‖ = √(3/2)·(4/3)με is still below √(2/3)σ_y here, so
+    # this strain must be elastic.
+    s_xx = (4 / 3) * μ * ε
+    @test sqrt(1.5) * s_xx < sqrt(2 / 3) * σ_y
+    @test Z_new[10] == 0.0                       # no plastic flow
+    @test σ[1, 1] ≈ (λ + 2 * μ) * ε rtol = 1e-2
+
+    # Push well past yield: plastic strain must accumulate monotonically.
+    eqps = Float64[]
+    for ε in (5.0e-3, 2.0e-2, 5.0e-2)
+        ∇u = Tensor{2, 3}((i, j) -> (i == 1 && j == 1) ? ε : 0.0)
+        Z_new = copy(initialize_state(model))
+        pk1_stress(model, props, initialize_state(model), Z_new, 0.0, ∇u, 0.0)
+        push!(eqps, Z_new[10])
+    end
+    @test all(eqps .> 0.0)
+    @test issorted(eqps)
+end
+
+function test_finite_def_j2_cauchy_from_pk1()
+    # σ = J⁻¹ P Fᵀ.  FiniteDefJ2Plasticity subtypes AbstractConstitutiveModel
+    # directly, so it does not inherit the hyperelastic cauchy_stress fallback
+    # and needs its own -- assert the two stay consistent.
+    model = FiniteDefJ2Plasticity()
+    inputs = Dict(
+        "density"           => 2700.0,
+        "Young's modulus"   => 70.0e9,
+        "Poisson's ratio"   => 0.36,
+        "yield stress"      => 250.0e6,
+        "hardening modulus" => 0.7e9,
+    )
+    props = initialize_props(model, inputs)
+
+    for ε in (1.0e-3, 3.0e-2)
+        ∇u = Tensor{2, 3}((i, j) -> (i == 1 && j == 1) ? ε : 0.0)
+        F  = ∇u + one(∇u)
+        Zp = copy(initialize_state(model))
+        Zs = copy(initialize_state(model))
+        P  = pk1_stress(model, props, initialize_state(model), Zp, 0.0, ∇u, 0.0)
+        σ  = cauchy_stress(model, props, initialize_state(model), Zs, 0.0, ∇u, 0.0)
+        @test σ ≈ (1 / det(F)) * dot(P, transpose(F))
+    end
+end
+
+function test_finite_def_j2_tangent_vs_fd()
+    # The analytic tangent must be the Jacobian of the same pk1_stress the
+    # residual evaluates.  This also pins the argument ORDER: the method was
+    # stranded with `(props, Δt, Z_old, Z_new, ...)` while the interface is
+    # `(props, Z_old, Z_new, Δt, ...)`, which would silently pass Δt as Z_old.
+    model = FiniteDefJ2Plasticity()
+    inputs = Dict(
+        "density"           => 2700.0,
+        "Young's modulus"   => 70.0e9,
+        "Poisson's ratio"   => 0.36,
+        "yield stress"      => 250.0e6,
+        "hardening modulus" => 0.7e9,
+    )
+    props = initialize_props(model, inputs)
+
+    for ε in (1.0e-3, 2.0e-2, 5.0e-2)     # elastic, then two plastic states
+        ∇u = Tensor{2, 3}((i, j) -> (i == 1 && j == 1) ? ε : 0.0)
+
+        Zs = copy(initialize_state(model))
+        A  = material_tangent(model, props, initialize_state(model), Zs, 0.0, ∇u, 0.0)
+
+        h  = 1.0e-8
+        Z0 = copy(initialize_state(model))
+        P0 = pk1_stress(model, props, initialize_state(model), Z0, 0.0, ∇u, 0.0)
+        for k in 1:3, l in 1:3
+            hh = max(h * abs(∇u[k, l]), h)
+            ∇p = Tensor{2, 3}((i, j) -> ∇u[i, j] + (i == k && j == l ? hh : 0.0))
+            Zp = copy(initialize_state(model))
+            Pp = pk1_stress(model, props, initialize_state(model), Zp, 0.0, ∇p, 0.0)
+            for i in 1:3, j in 1:3
+                @test isapprox(A[i, j, k, l], (Pp[i, j] - P0[i, j]) / hh;
+                               rtol = 1e-5, atol = 1e-3 * maximum(abs, P0))
+            end
+        end
+    end
+end
+
+test_finite_def_j2_interface()
+test_finite_def_j2_uniaxial_strain()
+test_finite_def_j2_cauchy_from_pk1()
+test_finite_def_j2_tangent_vs_fd()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ end
 end
 
 @testset "Models" begin
+    include("models/TestFiniteDefJ2Plasticity.jl")
     include("models/TestLinearElastic.jl")
     include("models/TestLinearElastoplastic.jl")
 end


### PR DESCRIPTION
Two pieces of fallout from the modularity refactor (fcf15f1), both found while
moving Carina.jl onto the new interface.

## 1. `FiniteDefJ2Plasticity` is no longer part of the package

fcf15f1 removed the `include` and `export` for `FiniteDefJ2Plasticity`. The
256-line Simo–Hughes implementation survived on disk but is not loaded, so
`CM.FiniteDefJ2Plasticity` raises `UndefVarError`. Nothing caught it — the model
had no test file.

Re-adding the two lines is not sufficient; the file was stranded partway through
the migration:

- **`<: AbstractMechanicalModel{4, 10}`** — that abstract type no longer exists
  anywhere in the package, so including the file failed to load outright. It now
  subtypes `AbstractConstitutiveModel` directly: the model is path dependent, so
  the hyperelastic defaults (AD tangents from a stored energy) are not
  appropriate for it.
- **Stale `{4, 10}` parameters** disagreed with `num_properties = 5`. The
  density-first change added ρ to the property vector but the type parameters
  were never updated. The method-based accessors are the source of truth now and
  were already correct.
- **`material_tangent` argument order** was left as
  `(props, Δt, Z_old, Z_new, ∇u, θ)` while the interface is
  `(props, Z_old, Z_new, Δt, ∇u, θ)`. That ordering compiles and would silently
  pass `Δt` where the old state belongs.
- **No `cauchy_stress`.** The generic fallbacks cover only
  `AbstractHyperelasticModel` and `AbstractLinearElasticModel`, so subtyping
  `AbstractConstitutiveModel` leaves the push-forward σ = J⁻¹PFᵀ to be written
  out explicitly. Downstream stress output needs it.

The parts that had been migrated were migrated correctly and are untouched:
`initialize_props` returns `[ρ, λ, μ, σ_y, H]`, the internal stress update and
tangent read `props[2:5]`, `p_wave_modulus` is λ + 2μ, and the state layout is
still `vec(Fᵖ) ++ α`.

## 2. `p_wave_modulus` is broken for every wrapper model

`Hyperelastic`, `LinearElastic`, `LinearElastoplastic` and `LinearThermoelastic`
each declare

```julia
function p_wave_modulus(::Hyperelastic, props)
```

with an unnamed first argument, but the body refers to `model.model` (or
`model.elastic_model`). Every call raises
`UndefVarError: `model` not defined in `ConstitutiveModels``. The inner module
implementations are fine; only the forwarding wrappers are affected.

## Tests

Adds `test/models/TestFiniteDefJ2Plasticity.jl`, the absence of which is why the
model could be dropped without a failure. It pins the module-level interface
(exported, density at `props[1]`, NP = 5, NS = 10, `eqps` last), checks elastic
response and monotonic plastic flow under uniaxial strain, checks
`cauchy_stress` against J⁻¹PFᵀ, and verifies the analytic tangent against finite
differences in both the elastic and plastic regimes — which is what pins the
argument order.

Verified numbers: elastic below yield gives σ₁₁ = (λ+2μ)ε = 117.6 MPa at
ε = 1e-3 with eqps = 0; yield initiates where von Mises predicts (‖s‖ crosses
√(2/3)σ_y between ε = 1e-3 and 5e-3, eqps = 9.2e-5); analytic vs finite-difference
tangent agrees to ~1e-8 in both regimes.

Models testset 2020 → 2281; full suite passes.