### PR TITLE
Fix state_variable_names for LinearElastoplastic

### DIFF
--- a/src/models/LinearElastoplastic.jl
+++ b/src/models/LinearElastoplastic.jl
@@ -33,7 +33,7 @@ end
 
 function state_variable_names(::LinearElastoplastic)
     return [
-        state_variable_names(SymmetricTensor{2, 3, T, 6}, "ep")...,
+        state_variable_names(zero(SymmetricTensor{2, 3, Float64, 6}), "ep")...,
         "eqps"
     ]
 end

--- a/test/models/TestLinearElastoplastic.jl
+++ b/test/models/TestLinearElastoplastic.jl
@@ -53,4 +53,17 @@ function test_linear_elasto_plasticity()
     test_linear_elasto_plasticity_uniaxial_stress(model, inputs)
 end
 
+function test_linear_elasto_plasticity_state_variable_names()
+    # state_variable_names(::LinearElastoplastic) referenced an undefined
+    # type parameter T and passed a tensor *type* to a helper dispatched on
+    # tensor *instances*, so asking a linear elastoplastic model for its
+    # state names threw UndefVarError.  The names must line up one to one
+    # with pack_state!: Z[1:6] = ε_p, Z[7] = eqps.
+    model = LinearElastoplastic(VonMises(LinearIsotropicHardening()))
+    names = state_variable_names(model)
+    @test names == ["ep_xx", "ep_xy", "ep_xz", "ep_yy", "ep_yz", "ep_zz", "eqps"]
+    @test length(names) == num_state_variables(model)
+end
+
 test_linear_elasto_plasticity()
+test_linear_elasto_plasticity_state_variable_names()


### PR DESCRIPTION
Asking a linear elastoplastic model for its state-variable names threw `UndefVarError`: the method references a type parameter `T` that is never bound, and it passes a tensor *type* to helpers dispatched on tensor *instances*, so no method would match even with `T` bound.

(An earlier version of this branch also rewrote the tensor-name helpers, but main has since fixed their prefixing and component order and pinned the instance-based API in `TestStateVariables` — so after rebasing, this PR is just the caller fix.)

Changes:
- `state_variable_names(::LinearElastoplastic)`: pass `zero(SymmetricTensor{2, 3, Float64, 6})`, matching the helper API the test suite pins.
- Test pinning the names one to one against the `pack_state!` layout (`Z[1:6] = ε_p`, `Z[7] = eqps`).

Full suite passes (9121 tests) on top of current main.