### PR TITLE
property_names interface

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -13,10 +13,23 @@ function initialize_props end
 function initialize_state end
 function num_properties end
 function num_state_variables end
-function property_names end # optional maybe?
+"""
+defines the property names that will be read in by the default
+``initialize_props`` method.
+"""
+function property_names end
 function state_variable_names end
 
 # defaults
+"""
+Default props constructor to just use property_names
+with no defaults. Supports sampling.
+"""
+function initialize_props(c::AbstractConstitutive, inputs::Dict{String})
+    prop_names = property_names(c)
+    return map(x -> get_property(inputs, x), prop_names)
+end
+
 """
 Default state constructor to just return zeros
 """
@@ -25,6 +38,9 @@ function initialize_state(c::AbstractConstitutive)
 end
 num_properties(model::AbstractConstitutive) = throw(UnImplementedMethodError("Need to implement num_properties method $(typeof(model))."))
 num_state_variables(model::AbstractConstitutive) = throw(UnImplementedMethodError("Need to implement num_state_variables method for $(typeof(model))"))
+function property_names(c::AbstractConstitutive)
+    throw(UnImplementedMethodError("property_names method needs to be implemented for $(typeof(c))"))
+end
 """
 Return human-readable names for each state variable, in storage order.
 Default fallback generates generic names: ["state_1", "state_2", ...].

--- a/src/models/FiniteDefJ2Plasticity.jl
+++ b/src/models/FiniteDefJ2Plasticity.jl
@@ -48,6 +48,13 @@ end
 num_properties(::FiniteDefJ2Plasticity) = 5
 num_state_variables(::FiniteDefJ2Plasticity) = 10
 
+function property_names(::FiniteDefJ2Plasticity)
+    return [
+        "density", "Lamé's first constant", "shear modulus",
+        "yield stress", "hardening modulus"
+    ]
+end
+
 function state_variable_names(::FiniteDefJ2Plasticity)
     return [
         "Fp_xx", "Fp_yx", "Fp_zx",

--- a/src/models/Hyperelastic.jl
+++ b/src/models/Hyperelastic.jl
@@ -11,6 +11,10 @@ end
 num_properties(model::Hyperelastic) = 1 + num_properties(model.model)
 num_state_variables(model::Hyperelastic) = 0
 
+function property_names(model::Hyperelastic)
+    return ["density", property_names(model.model)...]
+end
+
 function cauchy_stress(
     model::Hyperelastic,
     props, Z_old, Z_new, Δt, ∇u, θ

--- a/src/models/Hypoelastic.jl
+++ b/src/models/Hypoelastic.jl
@@ -18,6 +18,10 @@ end
 num_properties(::Hypoelastic) = 3
 num_state_variables(::Hypoelastic) = 7
 
+function property_names(::Hypoelastic)
+    return ["density", "Lamé's first constant", "shear modulus"]
+end
+
 function pack_state!(Z, ::Hypoelastic, σ, J)
     Z[1:6] .= σ.data
     Z[7] = J

--- a/src/models/LinearElastic.jl
+++ b/src/models/LinearElastic.jl
@@ -13,6 +13,10 @@ end
 num_properties(model::LinearElastic) = num_properties(model.model) + 1
 num_state_variables(model::LinearElastic) = 0
 
+function property_names(model::LinearElastic)
+    return ["density", property_names(model.model)...]
+end
+
 function cauchy_stress(
     model::LinearElastic,
     props, Z_old, Z_new, Δt, ε, θ

--- a/src/models/LinearElastoplastic.jl
+++ b/src/models/LinearElastoplastic.jl
@@ -21,6 +21,14 @@ end
 num_properties(model::LinearElastoplastic) = num_properties(model.elastic_model) + num_properties(model.yield_surface) + 1
 num_state_variables(model::LinearElastoplastic) = 6 + num_state_variables(model.yield_surface)
 
+function property_names(::LinearElastoplastic)
+    return [
+        "density",
+        property_names(model.elastic_model)...,
+        property_names(model.yield_surface)...
+    ]
+end
+
 function pack_state!(Z, model::LinearElastoplastic, ε_p, eqps, σ_b)
     # @show ε_p
     Z[1:6] .= ForwardDiff.value.(ε_p.data)

--- a/src/models/LinearThermoelastic.jl
+++ b/src/models/LinearThermoelastic.jl
@@ -45,10 +45,22 @@ function initialize_props(::LinearThermoelastic, inputs::Dict{String})
     ]
 end
 
-num_properties(::LinearThermoelastic) = 1 + num_properties(model.elastic_model) +
-    num_properties(model.heat_capacity_model) + num_properties(model.heat_flux_model) +
+num_properties(::LinearThermoelastic) = 1 +
+    num_properties(model.elastic_model) +
+    num_properties(model.heat_capacity_model) +
+    num_properties(model.heat_flux_model) +
     num_prony_terms(model.thermal_expansion_model)
 num_state_variables(::LinearThermoelastic) = 0
+
+function property_names(c::LinearThermoelastic)
+    return [
+        "density",
+        property_names(c.heat_capacity_model)...,
+        property_names(c.heat_flux_model)...,
+        property_names(c.thermal_expansion)...,
+        property_names(c.elastic_model)...
+    ]
+end
 
 function dissipation(
     ::LinearThermoelastic,

--- a/src/models/Thermal.jl
+++ b/src/models/Thermal.jl
@@ -14,6 +14,14 @@ end
 num_properties(model::Thermal) = num_properties(model.heat_capacity_model) + num_properties(model.heat_flux_model) + 1
 num_state_variables(model::Thermal) = 0
 
+function property_names(model::Thermal)
+    return [
+        "density",
+        property_names(model.heat_capacity_model)...,
+        property_names(model.heat_flux_model)...
+    ]
+end
+
 function dissipation(
     model::Thermal,
     props, Z_old, Z_new, Δt, ∇u, θ, ∇θ

--- a/src/modules/heat_capacity/HeatCapacity.jl
+++ b/src/modules/heat_capacity/HeatCapacity.jl
@@ -7,15 +7,12 @@ function helmholtz_free_energy end
 struct SimpleHeatCapacity <: AbstractHeatCapacity
 end
 
-function initialize_props(::SimpleHeatCapacity, inputs::Dict{String})
-    return [
-        get_property(inputs, "reference temperature"),
-        get_property(inputs, "specific heat capacity")
-    ]
-end
-
 num_properties(::SimpleHeatCapacity) = 2
 num_state_variables(::SimpleHeatCapacity) = 0
+
+function property_names(::SimpleHeatCapacity)
+    return ["reference temperature", "specific heat capacity"]
+end
 
 function disspation(::SimpleHeatCapacity, props, ∇u, θ)
     return zero(typeof(θ))

--- a/src/modules/heat_conduction/HeatConduction.jl
+++ b/src/modules/heat_conduction/HeatConduction.jl
@@ -41,18 +41,15 @@ struct FouriersLaw{S <: AbstractMaterialSymmetry{2}} <: AbstractHeatConduction
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
-function initialize_props(model::FouriersLaw, inputs::Dict{String})
+num_properties(model::FouriersLaw) = num_properties(model.symmetry)
+
+function property_names(model::FouriersLaw)
     if isa(model.symmetry, Isotropy{2})
-        return [initialize_props(model.symmetry, inputs, ["thermal conductivity"])...]
+        return property_names(model.symmetry, ["thermal conductivity"])
     else
         @assert false "Currently unsupported material symmetry type $(model.symmetry)"
     end
 end
-
-num_properties(model::FouriersLaw) = num_properties(model.symmetry)
 
 # TODO check against Gurtin-Fried-Anand
 function dissipation(model::FouriersLaw, props, kin, θ, ∇θ)

--- a/src/modules/hyperelasticity/ArrudaBoyce.jl
+++ b/src/modules/hyperelasticity/ArrudaBoyce.jl
@@ -9,6 +9,10 @@ end
 
 num_properties(::ArrudaBoyce) = 3
 
+function property_names(::ArrudaBoyce)
+    return ["bulk modulus", "shear modulus", "n"]
+end
+
 # using treloar approximation
 # function _inverse_langevin_approx(y)
 #     return 3 * y / (1 - (3 / 5 * y^2 + 36 / 175 * y^4 + 108 / 875 * y^6))

--- a/src/modules/hyperelasticity/Gent.jl
+++ b/src/modules/hyperelasticity/Gent.jl
@@ -15,6 +15,10 @@ end
 
 num_properties(::Gent) = 3
 
+function property_names(::Gent)
+    return ["bulk modulus", "shear modulus", "Jm"]
+end
+
 """
 ``\\psi = \\frac{1}{2}\\left[\\frac{1}{2}\\left(J^2 - 1\\right) - \\ln J\\right]
         - \\frac{1}{2}\\mu J_m\\ln\\left(1 - \\frac{\\bar{I}_1 - 3}{Jm}\\right)``

--- a/src/modules/hyperelasticity/Hencky.jl
+++ b/src/modules/hyperelasticity/Hencky.jl
@@ -14,6 +14,10 @@ end
 
 num_properties(::Hencky) = 2
 
+function property_names(::Hencky)
+    return ["bulk modulus", "shear modulus"]
+end
+
 """
 ``
 \\psi = \\frac{1}{2}\\kappa tr\\left(\\mathbf{E}\\right)^2 +

--- a/src/modules/hyperelasticity/LinearElasticity.jl
+++ b/src/modules/hyperelasticity/LinearElasticity.jl
@@ -14,6 +14,10 @@ end
 
 num_properties(::LinearElasticity) = 2
 
+function property_names(::LinearElasticity)
+    return ["Lamé's first constant", "shear modulus"]
+end
+
 """
 ``\\psi = \\frac{1}{2}\\lambda tr\\left(\\varepsilon\\right)^2
         + \\mu \\varepsilon:\\varepsilon``

--- a/src/modules/hyperelasticity/MooneyRivlin.jl
+++ b/src/modules/hyperelasticity/MooneyRivlin.jl
@@ -16,6 +16,10 @@ end
 
 num_properties(::MooneyRivlin) = 3
 
+function property_names(::MooneyRivlin)
+    return ["bulk modulus", "C1", "C2"]
+end
+
 """
 ``\\psi = \\frac{1}{2}\\left[\\frac{1}{2}\\left(J^2 - 1\\right) - \\ln J\\right]
         + C_1\\left(\\bar{I}_1 - 3\\right)

--- a/src/modules/hyperelasticity/NeoHookean.jl
+++ b/src/modules/hyperelasticity/NeoHookean.jl
@@ -15,6 +15,10 @@ end
 
 num_properties(::NeoHookean) = 2
 
+function property_names(::NeoHookean)
+    return ["bulk modulus", "shear modulus"]
+end
+
 """
 ``\\psi = \\frac{1}{2}\\left[\\frac{1}{2}\\left(J^2 - 1\\right) - \\ln J\\right]
         + \\frac{1}{2}\\mu\\left(\\bar{I}_1 - 3\\right)``

--- a/src/modules/hyperelasticity/SaintVenantKirchhoff.jl
+++ b/src/modules/hyperelasticity/SaintVenantKirchhoff.jl
@@ -31,6 +31,10 @@ end
 
 num_properties(::SaintVenantKirchhoff) = 2
 
+function property_names(::SaintVenantKirchhoff)
+    return ["Lamé's first constant", "shear modulus"]
+end
+
 """
 $(TYPEDSIGNATURES)
 """

--- a/src/modules/hyperelasticity/SethHill.jl
+++ b/src/modules/hyperelasticity/SethHill.jl
@@ -32,6 +32,10 @@ end
 
 num_properties(::SethHill) = 4
 
+function property_names(::SethHill)
+    return ["bulk modulus", "shear modulus", "m", "n"]
+end
+
 """
 $(TYPEDSIGNATURES)
 """

--- a/src/modules/plasticity/IsotropicHardening.jl
+++ b/src/modules/plasticity/IsotropicHardening.jl
@@ -10,11 +10,8 @@ function hardening_hessian end
 struct NoIsotropicHardening <: AbstractIsotropicHardening
 end
 
-function initialize_props(::NoIsotropicHardening, inputs::Dict{String})
-    return [get_property(inputs, "yield stress")]
-end
-
 num_properties(::NoIsotropicHardening) = 1
+property_names(::NoIsotropicHardening) = ["yield stress"]
 
 hardening_energy(::NoIsotropicHardening, props, eqps) = props[1] * eqps
 hardening_gradient(::NoIsotropicHardening, props, eqps) = props[1]
@@ -23,14 +20,8 @@ hardening_hessian(::NoIsotropicHardening, props, eqps) = zero(typeof(eqps))
 struct LinearIsotropicHardening <: AbstractIsotropicHardening
 end
 
-function initialize_props(::LinearIsotropicHardening, inputs::Dict{String})
-    return [
-        get_property(inputs, "yield stress"),
-        get_property(inputs, "hardening modulus")
-    ]
-end
-
 num_properties(::LinearIsotropicHardening) = 2
+property_names(::LinearIsotropicHardening) = ["yield stress", "hardening modulus"]
 
 hardening_energy(::LinearIsotropicHardening, props, eqps) = props[1] * eqps + 0.5 * props[2] * eqps * eqps
 hardening_gradient(::LinearIsotropicHardening, props, eqps) = props[1] + props[2] * eqps
@@ -39,16 +30,11 @@ hardening_hessian(::LinearIsotropicHardening, props, eqps) = props[2]
 struct PowerLawIsotropicHardening <: AbstractIsotropicHardening
 end
 
-function initialize_props(::PowerLawIsotropicHardening, inputs::Dict{String})
-    return [
-        get_property(inputs, "yield stress"),         # σ_y
-        get_property(inputs, "hardening coefficient"),# K
-        get_property(inputs, "hardening exponent"),   # n
-        get_property(inputs, "luders strain")         # ε_L
-    ]
-end
-
 num_properties(::PowerLawIsotropicHardening) = 4
+property_names(::PowerLawIsotropicHardening) = [
+    "yield stress", "hardening coefficient",
+    "hardening exponent", "luders strain"
+]
 
 function hardening_energy(::PowerLawIsotropicHardening, props, eqps)
     σy = props[1]
@@ -95,16 +81,11 @@ end
 struct Voce <: AbstractIsotropicHardening
 end
 
-function initialize_props(::Voce, inputs::Dict{String})
-    return [
-        get_property(inputs, "yield stress"),
-        get_property(inputs, "hardening modulus"),
-        get_property(inputs, "saturation stress"),
-        get_property(inputs, "hardening exponent")
-    ]
-end
-
 num_properties(::Voce) = 4
+property_names(::Voce) = [
+    "yield stress", "hardening modulus",
+    "saturation stress", "hardening exponent"
+]
 
 # hardening_energy(::Voce, props, eqps) = props[1] * eqps + 0.5 * props[2] * eqps * eqps + props[3] * eqps - 
 # hardening_gradient(::Voce, props, eqps) = props[1] + props[2] * eqps

--- a/src/modules/plasticity/YieldSurfaces.jl
+++ b/src/modules/plasticity/YieldSurfaces.jl
@@ -12,12 +12,6 @@ struct VonMises{I} <: AbstractYieldSurface{I}
     isotropic_hardening_model::I
 end
 
-function initialize_props(model::VonMises, inputs::Dict{String})
-    return [
-        initialize_props(model.isotropic_hardening_model, inputs)...
-    ]
-end
-
 function initialize_state(model::VonMises)
     return [
         zero(SymmetricTensor{2, 3, Float64, 6}).data...,
@@ -26,6 +20,7 @@ function initialize_state(model::VonMises)
 end
 
 num_properties(model::VonMises) = num_properties(model.isotropic_hardening_model)
+property_names(model::VonMises) = property_names(model.isotropic_hardening_model)
 num_state_variables(model::VonMises) = num_state_variables(model.isotropic_hardening_model)
 
 function effective_stress(::VonMises, props, σ)

--- a/src/modules/thermal_expansion/ThermalExpansion.jl
+++ b/src/modules/thermal_expansion/ThermalExpansion.jl
@@ -20,6 +20,14 @@ end
 
 num_properties(model::LinearThermalExpansion) = 1 + num_properties(model.symmetry)
 
+function property_names(model::LinearThermalExpansion)
+    if isa(model.symmetry, Isotropy{2})
+        prop_names = ["reference temperature", "β"]
+    else
+        @assert false "Currently unsupported material symmetry type $(model.symmetry)"
+    end
+end
+
 function cauchy_stress(model::LinearThermalExpansion, props, ::SymmetricTensor{2, 3, T, 6}, θ) where T <: Number
     θ_0 = props[1]
     M_props = module_props(model.symmetry, props, 2)

--- a/src/utils/ElasticConstants.jl
+++ b/src/utils/ElasticConstants.jl
@@ -132,3 +132,14 @@ function Base.show(io::IO, e::ElasticConstants)
     println(io, "  shear modulus         = $(e.μ)")
     println(io, "  Young's Modulus       = $(e.E)")
 end
+
+function to_dict(e::ElasticConstants{T}) where T <: Number
+    d = Dict{String, T}(
+        "bulk modulus"          => e.κ,
+        "Lamé's first constant" => e.λ,
+        "Poisson's ratio"       => e.ν,
+        "shear modulus"         => e.μ,
+        "Young's modulus"       => e.E
+    )
+    return d
+end

--- a/src/utils/MaterialSymmetry.jl
+++ b/src/utils/MaterialSymmetry.jl
@@ -37,3 +37,11 @@ end
 
 num_properties(::Isotropy{2}) = 1
 num_properties(::Isotropy{4}) = 2
+
+function property_names(::Isotropy{2}, keys)
+    return [keys[1]]
+end
+
+function property_names(::Isotropy{4}, keys)
+    return [keys[1], keys[2]]
+end


### PR DESCRIPTION
Adding property_names interface. By default if a model/module does not implement the initialize_props interface it will fall back to calling property_names and then reading from an input Dict and return an array based on the order of the property_names vector. This should be used over the initialize_props interface unless special stuff needs to be done, like e.g. using the ElasticConstants struct, calculating derived properties, or setting defaults. This is meant to serve as an easy blanket implementation and also a way to allow for easy output to exodus.